### PR TITLE
Integrate the default osx time

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,10 @@ galitime
 Introduction
 ------------
 
-Software for benchmarking programs using `GNU Time <https://www.gnu.org/software/time/>`_.
+Software for benchmarking programs using the `GNU Time <https://www.gnu.org/software/time/>`_ command,
+with extensive benchmarking options and unified behaviour across platforms (including output units).
+Inspired by the benchmarking script in `Phylign <https://github.com/karel-brinda/phylign>`_
+developed by `Leandro Lima <https://github.com/leoisl>`_.
 
 
 
@@ -94,15 +97,16 @@ Output
 ------
 
 * ``experiment`` - Name of the experiment, if provided via ``-n``
+* ``run`` - Number of run in case of multiple repetitions
 * ``real_s`` - Real time in seconds (wall clock time)
+* ``real_s_py`` - Python-measured real time in seconds (slightly higher than ``real_s``)
 * ``user_s`` - User CPU time in seconds (user mode, excluding system calls)
 * ``sys_s`` - System CPU time in seconds (kernel mode)
 * ``percent_cpu`` - CPU usage percentage
 * ``max_ram_kb`` - Maximum RAM usage in kilobytes
-* ``exit_code`` - Exit code of the command (0 if everything ok)
+* ``exit_code`` - Exit code of the command (0 if everything ok, -1 if command failed)
 * ``fs_inputs`` - File system read read operations count
 * ``fs_outputs`` - File system write operations count
-* ``real_s_alt`` - Python-measured real time in seconds (slightly higher than ``real_s``)
 * ``command`` - Command executed, with tabs replaced by spaces
 
 
@@ -127,8 +131,7 @@ Licence
 `MIT <https://github.com/karel-brinda/galitime/blob/master/LICENSE.txt>`_
 
 
-Authors
+Contact
 -------
 
 * `Karel Brinda <http://brinda.eu>`_ <karel.brinda@inria.fr>
-* `Leandro Lima <https://github.com/leoisl>`_

--- a/README.rst
+++ b/README.rst
@@ -47,9 +47,8 @@ Installation
 Dependencies
 ~~~~~~~~~~~~
 
-Galitime has no dependencies beyond Python 3. However, on OS X
-it requires the GNU version of the :code:`time` command (:code:`gtime`),
-which can be installed by :code:`brew install gnu-time`.
+Galitime has no dependencies beyond Python 3. While it used to require gtime on OS X, this dependency is no
+longer required and the default time command is used.
 
 
 Using Bioconda

--- a/galitime/galitime.py
+++ b/galitime/galitime.py
@@ -103,7 +103,7 @@ class AbstractTime(ABC):
         """
         # TODO: change to /usr/bin/env bash
         wrapped_cmd = f'{self.wrapper()} {self.cmd}'
-        print(f"Running '{wrapped_cmd}'")
+        #print(f"Running '{wrapped_cmd}'")
         main_process = subprocess.Popen(wrapped_cmd, shell=True, executable='/bin/bash')
 
         #TODO: integrate timeout into the whole method

--- a/galitime/galitime.py
+++ b/galitime/galitime.py
@@ -147,10 +147,10 @@ class GnuTime(AbstractTime):
     def __init__(self, cmd, experiment=None):
         super().__init__(cmd=cmd, experiment=experiment)
         if sys.platform == "linux":
-            time_command = "/usr/bin/time"
+            time_command = "/usr/bin/env time"
         elif sys.platform == "darwin":
             # TODO: verify gtime is present
-            time_command = "gtime"
+            time_command = "/usr/bin/env gtime"
         else:
             raise Exception("Unsupported OS")
 

--- a/galitime/galitime.py
+++ b/galitime/galitime.py
@@ -46,6 +46,9 @@ class TimingResult:
         self.set('run', run)
         self.set('command', command)
 
+    def bin_to_si(self, key):
+        self._data[key] = int(round(int(self._data[key]) * 1.024))
+
     def __getitem__(self, key):
         return self._data[key]
 
@@ -168,6 +171,7 @@ class GnuTime(AbstractTime):
             gtime_output_values = tmp_fo.readline().strip().split("\t")
         for k, v in zip(self.gtime_columns, gtime_output_values):
             self.current_result.set(k, v)
+        self.current_result.bin_to_si("max_ram_kb")
 
 
 class MacTime(AbstractTime):
@@ -188,9 +192,16 @@ class MacTime(AbstractTime):
                 x = x.strip()
                 v, k = x.split(maxsplit=1)
                 if v in ["real", "user", "sys"]:
-                    d[v] = k
+                    kk = v
+                    vv = k
                 else:
-                    d[k] = v
+                    kk = k
+                    vv = v
+                if vv.isdigit():
+                    vvv = int(vv)
+                else:
+                    vvv = vv
+                d[kk] = vvv
         return d
 
     def _parse_result(self):
@@ -199,8 +210,8 @@ class MacTime(AbstractTime):
         self.current_result.set("real_s", d["real"])
         self.current_result.set("user_s", d["user"])
         self.current_result.set("sys_s", d["sys"])
-        self.current_result.add("max_ram_kb_alt", d["maximum resident set size"])
-        self.current_result.set("max_ram_kb", d["peak memory footprint"])
+        self.current_result.set("max_ram_kb", int(round(d["maximum resident set size"] / 1000)))
+        self.current_result.add("max_ram_kb_alt", int(round(d["peak memory footprint"] / 1000)))
 
         #for k, v in zip(self.gtime_columns, gtime_output_values):
         #    self.current_result[k] = v

--- a/galitime/version.py
+++ b/galitime/version.py
@@ -2,4 +2,4 @@ try:
     from __commit import *
 except ImportError:
     pass
-VERSION = "0.1.3"
+VERSION = "0.2.0"


### PR DESCRIPTION
A major rewrite of the package. Now supports different time commands, no longer requiring the gtime dependency on mac.

closes #26