### PR TITLE
Revise TSV output schema and NA handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,18 +132,18 @@ Output columns
 
 ``galitime`` writes tab-delimited output with these columns:
 
-1. ``experiment`` – experiment name supplied with ``-n/--name``; otherwise empty
-2. ``run`` – repetition number when ``-r/--reps`` is greater than 1; otherwise empty
+1. ``experiment`` – experiment name supplied with ``-n/--name``; otherwise ``NA``
+2. ``run`` – 1-based repetition number
 3. ``real_s`` – wall-clock time reported by ``time``, in seconds
-4. ``real_s_py`` – wall-clock time measured by Python around the whole execution
-5. ``user_s`` – user CPU time in seconds
-6. ``sys_s`` – system CPU time in seconds
-7. ``percent_cpu`` – CPU usage percentage reported by ``time``
+4. ``user_s`` – user CPU time in seconds
+5. ``sys_s`` – system CPU time in seconds
+6. ``cpu_s`` – total CPU time in seconds (``user_s + sys_s``)
+7. ``cpu_pct`` – Average CPU utilization percentage, computed as ``100 * (user_s + sys_s) / real_s``.
+   Values above 100 indicate parallel CPU use.
 8. ``max_ram_kb`` – maximum resident memory in kilobytes
-9. ``fs_inputs`` – file system input operations
-10. ``fs_outputs`` – file system output operations
-11. ``exit_code`` – exit status of the benchmarked command
-12. ``command`` – normalized command string that was executed
+9. ``status`` – run outcome: ``ok``, ``failed``, ``timeout``, or ``timing_error``
+10. ``exit_code`` – exit status of the benchmarked command; ``NA`` when unavailable
+11. ``command`` – normalized command string that was executed
 
 Development
 -----------

--- a/galitime
+++ b/galitime
@@ -61,6 +61,10 @@ DEFAULT_r = 1
 DEFAULT_s = '/usr/bin/env bash'
 DEFAULT_s = shutil.which('bash')
 NA_VALUE = "NA"
+STATUS_OK = "ok"
+STATUS_FAILED = "failed"
+STATUS_TIMEOUT = "timeout"
+STATUS_TIMING_ERROR = "timing_error"
 
 
 # IMPORTANT NOTE: some results are parsed from text files so no assumptions should be made
@@ -75,7 +79,7 @@ class TimingResult:
         # 1. prefill table with the mandatory fields in the right order
         mandatory_columns = (
             "experiment", "run", "real_s", "user_s", "sys_s", "cpu_s",
-            "max_ram_kb", "fs_inputs", "fs_outputs", "exit_code", "command"
+            "max_ram_kb", "fs_inputs", "fs_outputs", "status", "exit_code", "command"
         )
         for x in mandatory_columns:
             self.add(x, NA_VALUE)
@@ -154,16 +158,34 @@ class AbstractTime(ABC):
                 experiment=self.experiment, run=run, command=self.command_simpl
             )
 
-            self._execute_time()
-            self._parse_result()
-            self._set_cpu_time()
+            try:
+                self._execute_time()
+                self._parse_result()
+                self._set_cpu_time()
+                self._set_status()
+            except Exception as err:
+                self.current_result.set("status", STATUS_TIMING_ERROR)
+                print(f"Galitime error: timing error ({err})", file=sys.stderr)
+                self.final_exit_code = 1
+                self._save_result()
+                break
+
             self._save_result()
 
-            exit_code = int(self.current_result['exit_code'])
-            if exit_code != 0:
+            status = self.current_result["status"]
+            if status == STATUS_OK:
+                continue
+
+            if status == STATUS_FAILED:
+                exit_code = int(self.current_result['exit_code'])
                 print(f"Galitime error: non-zero exit code ({exit_code})", file=sys.stderr)
                 self.final_exit_code = exit_code
-                break
+            elif status == STATUS_TIMEOUT:
+                print("Galitime error: command timed out", file=sys.stderr)
+                self.final_exit_code = 124
+            else:
+                self.final_exit_code = 1
+            break
             #
             # TODO: Add error treatment based on the user pre-specified failure mode
             # See https://github.com/karel-brinda/galitime/issues/25
@@ -194,11 +216,13 @@ class AbstractTime(ABC):
 
         #TODO: integrate timeout into the whole method
         timeout = None
+        timed_out = False
         try:
             # comment: returncode not the same as int (see https://docs.python.org/3/library/subprocess.html#subprocess.Popen.returncode)
             exit_code = self._normalize_exit_code(int(main_process.wait(timeout=timeout)))
         except subprocess.TimeoutExpired:
-            exit_code = -1  # timeout
+            timed_out = True
+            exit_code = None
         try:
             with open(self.current_exit_code_fn()) as exit_code_fo:
                 exit_code_lines = [x.strip() for x in exit_code_fo if x.strip()]
@@ -208,6 +232,8 @@ class AbstractTime(ABC):
             if len(exit_code_lines) != 1:
                 raise RuntimeError(f"Unexpected exit code output shape: {exit_code_lines!r}")
             exit_code = int(exit_code_lines[0])
+        if timed_out and exit_code is None:
+            self.current_result.set("status", STATUS_TIMEOUT)
         self.current_result.set("exit_code", exit_code)
 
         ## TODO: different treating based on the expected behaviour
@@ -220,6 +246,15 @@ class AbstractTime(ABC):
         user_s = float(self.current_result["user_s"])
         sys_s = float(self.current_result["sys_s"])
         self.current_result.set("cpu_s", user_s + sys_s)
+
+    def _set_status(self):
+        if self.current_result["status"] != NA_VALUE:
+            return
+        exit_code = int(self.current_result["exit_code"])
+        if exit_code == 0:
+            self.current_result.set("status", STATUS_OK)
+        else:
+            self.current_result.set("status", STATUS_FAILED)
 
     def _save_result(self):
         self.results.append(self.current_result)

--- a/galitime
+++ b/galitime
@@ -71,8 +71,8 @@ STATUS_TIMING_ERROR = "timing_error"
 # the integers being converted to int from str
 class TimingResult:
     PRINTED_COLUMNS = (
-        "experiment", "run", "real_s", "user_s", "sys_s", "cpu_s", "max_ram_kb", "status",
-        "exit_code", "command"
+        "experiment", "run", "real_s", "user_s", "sys_s", "cpu_s", "cpu_pct",
+        "max_ram_kb", "status", "exit_code", "command"
     )
 
     def __init__(self, experiment=None, run=None, command=None):
@@ -82,8 +82,8 @@ class TimingResult:
 
         # 1. prefill table with the mandatory fields in the right order
         mandatory_columns = (
-            "experiment", "run", "real_s", "user_s", "sys_s", "cpu_s", "max_ram_kb", "fs_inputs",
-            "fs_outputs", "status", "exit_code", "command"
+            "experiment", "run", "real_s", "user_s", "sys_s", "cpu_s", "cpu_pct",
+            "max_ram_kb", "fs_inputs", "fs_outputs", "status", "exit_code", "command"
         )
         for x in mandatory_columns:
             self.add(x, NA_VALUE)
@@ -120,8 +120,14 @@ class TimingResult:
     def __repr__(self):
         return repr(self._data)
 
+    @staticmethod
+    def _format_printed_value(key, value):
+        if key == "cpu_pct" and value != NA_VALUE:
+            return f"{value}%"
+        return value
+
     def __str__(self):
-        printed_values = [self._data[k] for k in self.PRINTED_COLUMNS]
+        printed_values = [self._format_printed_value(k, self._data[k]) for k in self.PRINTED_COLUMNS]
         return "\t".join(self.PRINTED_COLUMNS) + "\n" + "\t".join(map(str, printed_values))
 
 
@@ -166,6 +172,7 @@ class AbstractTime(ABC):
                 self._execute_time()
                 self._parse_result()
                 self._set_cpu_time()
+                self._set_cpu_pct()
                 self._set_status()
             except Exception as err:
                 self.current_result.set("status", STATUS_TIMING_ERROR)
@@ -250,6 +257,14 @@ class AbstractTime(ABC):
         user_s = float(self.current_result["user_s"])
         sys_s = float(self.current_result["sys_s"])
         self.current_result.set("cpu_s", user_s + sys_s)
+
+    def _set_cpu_pct(self):
+        real_s = float(self.current_result["real_s"])
+        cpu_s = float(self.current_result["cpu_s"])
+        if real_s <= 0:
+            self.current_result.set("cpu_pct", None)
+        else:
+            self.current_result.set("cpu_pct", 100.0 * cpu_s / real_s)
 
     def _set_status(self):
         if self.current_result["status"] != NA_VALUE:

--- a/galitime
+++ b/galitime
@@ -60,6 +60,7 @@ DEFAULT_l = "stderr"
 DEFAULT_r = 1
 DEFAULT_s = '/usr/bin/env bash'
 DEFAULT_s = shutil.which('bash')
+NA_VALUE = "NA"
 
 
 # IMPORTANT NOTE: some results are parsed from text files so no assumptions should be made
@@ -77,7 +78,7 @@ class TimingResult:
             "max_ram_kb", "fs_inputs", "fs_outputs", "exit_code", "command"
         )
         for x in mandatory_columns:
-            self.add(x, None)
+            self.add(x, NA_VALUE)
 
         # 2. insert experiment parameters
         self.set('experiment', experiment)
@@ -96,11 +97,11 @@ class TimingResult:
 
     def set(self, key, value):
         assert key in self._data, f"The key '{key}' is not in the TimingResult dict after initialization, likely a bug (present keys: {self._data.keys()})"
-        self._data[key] = value
+        self._data[key] = NA_VALUE if value is None else value
 
     def add(self, key, value):
         assert key not in self._data, f"The key '{key}' is already in the TimingResult dict after initialization, likely a bug (present keys: {self._data.keys()})"
-        self._data[key] = value
+        self._data[key] = NA_VALUE if value is None else value
 
     def __delitem__(self, key):
         del self._data[key]

--- a/galitime
+++ b/galitime
@@ -149,7 +149,7 @@ class AbstractTime(ABC):
         """
         for i in range(times):
             self.current_i += 1
-            run = None if times == 1 else self.current_i
+            run = self.current_i
             self.current_result = TimingResult(
                 experiment=self.experiment, run=run, command=self.command_simpl
             )

--- a/galitime
+++ b/galitime
@@ -49,7 +49,7 @@ from pathlib import Path
 
 PROGRAM = 'galitime'
 DESC = 'benchmarking of computational experiments using GNU time'
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __author__ = "Karel Brinda"
 __email__ = "karel.brinda@inria.fr"
 __license__ = "MIT"

--- a/galitime
+++ b/galitime
@@ -35,7 +35,6 @@ SOFTWARE.
 
 import argparse
 import collections
-import datetime
 import os
 import shlex
 import re
@@ -74,7 +73,7 @@ class TimingResult:
 
         # 1. prefill table with the mandatory fields in the right order
         mandatory_columns = (
-            "experiment", "run", "real_s", "real_s_py", "user_s", "sys_s", "percent_cpu",
+            "experiment", "run", "real_s", "user_s", "sys_s", "cpu_s",
             "max_ram_kb", "fs_inputs", "fs_outputs", "exit_code", "command"
         )
         for x in mandatory_columns:
@@ -156,6 +155,7 @@ class AbstractTime(ABC):
 
             self._execute_time()
             self._parse_result()
+            self._set_cpu_time()
             self._save_result()
 
             exit_code = int(self.current_result['exit_code'])
@@ -193,13 +193,11 @@ class AbstractTime(ABC):
 
         #TODO: integrate timeout into the whole method
         timeout = None
-        start_time = datetime.datetime.now()
         try:
             # comment: returncode not the same as int (see https://docs.python.org/3/library/subprocess.html#subprocess.Popen.returncode)
             exit_code = self._normalize_exit_code(int(main_process.wait(timeout=timeout)))
         except subprocess.TimeoutExpired:
             exit_code = -1  # timeout
-        end_time = datetime.datetime.now()
         try:
             with open(self.current_exit_code_fn()) as exit_code_fo:
                 exit_code_lines = [x.strip() for x in exit_code_fo if x.strip()]
@@ -209,7 +207,6 @@ class AbstractTime(ABC):
             if len(exit_code_lines) != 1:
                 raise RuntimeError(f"Unexpected exit code output shape: {exit_code_lines!r}")
             exit_code = int(exit_code_lines[0])
-        self.current_result.set("real_s_py", (end_time - start_time).total_seconds())
         self.current_result.set("exit_code", exit_code)
 
         ## TODO: different treating based on the expected behaviour
@@ -217,6 +214,11 @@ class AbstractTime(ABC):
     @abstractmethod
     def _parse_result(self):
         pass
+
+    def _set_cpu_time(self):
+        user_s = float(self.current_result["user_s"])
+        sys_s = float(self.current_result["sys_s"])
+        self.current_result.set("cpu_s", user_s + sys_s)
 
     def _save_result(self):
         self.results.append(self.current_result)
@@ -257,7 +259,7 @@ class GnuTime(AbstractTime):
             raise RuntimeError(f"Unexpected GNU time output shape: {gtime_output_lines!r}")
         # GNU time's %x is useful for metrics/debugging, but the shell wait status is the canonical exit code.
         for k, v in zip(self.gtime_columns, gtime_output_values):
-            if k == "exit_code":
+            if k in {"percent_cpu", "exit_code"}:
                 continue
             self.current_result.set(k, v)
         self.current_result.bin_to_si("max_ram_kb")
@@ -302,7 +304,6 @@ class MacTime(AbstractTime):
         self.current_result.set("user_s", d["user"])
         self.current_result.set("sys_s", d["sys"])
         self.current_result.set("max_ram_kb", int(round(d["maximum resident set size"] / 1000)))
-        self.current_result.add("max_ram_kb_alt", int(round(d["peak memory footprint"] / 1000)))
 
         #for k, v in zip(self.gtime_columns, gtime_output_values):
         #    self.current_result[k] = v

--- a/galitime
+++ b/galitime
@@ -70,6 +70,10 @@ STATUS_TIMING_ERROR = "timing_error"
 # IMPORTANT NOTE: some results are parsed from text files so no assumptions should be made
 # the integers being converted to int from str
 class TimingResult:
+    PRINTED_COLUMNS = (
+        "experiment", "run", "real_s", "user_s", "sys_s", "cpu_s", "max_ram_kb", "status",
+        "exit_code", "command"
+    )
 
     def __init__(self, experiment=None, run=None, command=None):
         """Setup all the fields
@@ -78,8 +82,8 @@ class TimingResult:
 
         # 1. prefill table with the mandatory fields in the right order
         mandatory_columns = (
-            "experiment", "run", "real_s", "user_s", "sys_s", "cpu_s",
-            "max_ram_kb", "fs_inputs", "fs_outputs", "status", "exit_code", "command"
+            "experiment", "run", "real_s", "user_s", "sys_s", "cpu_s", "max_ram_kb", "fs_inputs",
+            "fs_outputs", "status", "exit_code", "command"
         )
         for x in mandatory_columns:
             self.add(x, NA_VALUE)
@@ -117,8 +121,8 @@ class TimingResult:
         return repr(self._data)
 
     def __str__(self):
-        return "\t".join(map(str, self._data.keys())
-                         ) + "\n" + "\t".join(map(str, self._data.values()))
+        printed_values = [self._data[k] for k in self.PRINTED_COLUMNS]
+        return "\t".join(self.PRINTED_COLUMNS) + "\n" + "\t".join(map(str, printed_values))
 
 
 class AbstractTime(ABC):

--- a/tests/02_simple_tests/Makefile
+++ b/tests/02_simple_tests/Makefile
@@ -10,7 +10,7 @@ UNAME_S := $(shell uname -s)
 
 BASE_TARGETS := test_file_log test_stderr_default test_stdout_log test_repeat
 TOTAL_STEPS := 4
-EXPECTED_HEADER := experiment	run	real_s	user_s	sys_s	cpu_s	max_ram_kb	fs_inputs	fs_outputs	exit_code	command
+EXPECTED_HEADER := experiment	run	real_s	user_s	sys_s	cpu_s	cpu_pct	max_ram_kb	status	exit_code	command
 
 ifeq ($(UNAME_S),Darwin)
 BASE_TARGETS += test_gtime_stdout_log test_gtime_file_log
@@ -30,14 +30,19 @@ define ASSERT_TSV_OK
 				print "ERROR: unexpected header in $(1): " $$0; \
 				exit 1; \
 			} \
+			for (i = 1; i <= NF; i++) if ($$i == "status") st = i; \
 			for (i = 1; i <= NF; i++) if ($$i == "exit_code") ec = i; \
-			if (!ec) { \
-				print "ERROR: missing exit_code column in $(1)"; \
+			if (!st || !ec) { \
+				print "ERROR: missing status or exit_code column in $(1)"; \
 				exit 1; \
 			} \
 			next; \
 		} \
 		NR > 1 { \
+			if ($$st != "ok") { \
+				print "ERROR: unexpected status in $(1): " $$0; \
+				exit 1; \
+			} \
 			if ($$ec != 0) { \
 				print "ERROR: non-zero exit_code in $(1): " $$0; \
 				exit 1; \

--- a/tests/02_simple_tests/Makefile
+++ b/tests/02_simple_tests/Makefile
@@ -10,6 +10,7 @@ UNAME_S := $(shell uname -s)
 
 BASE_TARGETS := test_file_log test_stderr_default test_stdout_log test_repeat
 TOTAL_STEPS := 4
+EXPECTED_HEADER := experiment	run	real_s	user_s	sys_s	cpu_s	max_ram_kb	fs_inputs	fs_outputs	exit_code	command
 
 ifeq ($(UNAME_S),Darwin)
 BASE_TARGETS += test_gtime_stdout_log test_gtime_file_log
@@ -25,8 +26,8 @@ define ASSERT_TSV_OK
 	}
 	@awk -F '\t' '\
 		NR == 1 { \
-			if ($$1 != "experiment") { \
-				print "ERROR: first column is not experiment in $(1)"; \
+			if ($$0 != "$(EXPECTED_HEADER)") { \
+				print "ERROR: unexpected header in $(1): " $$0; \
 				exit 1; \
 			} \
 			for (i = 1; i <= NF; i++) if ($$i == "exit_code") ec = i; \

--- a/tests/03_installed_version/Makefile
+++ b/tests/03_installed_version/Makefile
@@ -9,7 +9,7 @@ VENV := $(CURDIR)/_venv
 PIP := $(VENV)/bin/python -m pip
 GALITIME := $(VENV)/bin/galitime
 VERSION_RE := ^galitime [0-9]+(\.[0-9]+)+([A-Za-z0-9._+-]*)$$
-EXPECTED_HEADER := experiment	run	real_s	user_s	sys_s	cpu_s	max_ram_kb	fs_inputs	fs_outputs	exit_code	command
+EXPECTED_HEADER := experiment	run	real_s	user_s	sys_s	cpu_s	cpu_pct	max_ram_kb	status	exit_code	command
 
 all: test_create_venv test_install_package test_installed_version test_installed_stdout_log
 

--- a/tests/03_installed_version/Makefile
+++ b/tests/03_installed_version/Makefile
@@ -9,6 +9,7 @@ VENV := $(CURDIR)/_venv
 PIP := $(VENV)/bin/python -m pip
 GALITIME := $(VENV)/bin/galitime
 VERSION_RE := ^galitime [0-9]+(\.[0-9]+)+([A-Za-z0-9._+-]*)$$
+EXPECTED_HEADER := experiment	run	real_s	user_s	sys_s	cpu_s	max_ram_kb	fs_inputs	fs_outputs	exit_code	command
 
 all: test_create_venv test_install_package test_installed_version test_installed_stdout_log
 
@@ -27,7 +28,8 @@ test_installed_version: test_install_package
 
 test_installed_stdout_log: test_install_package
 	@echo "[4/4] Installed CLI stdout logging check"
-	@$(GALITIME) --log stdout "true" | grep -q '^experiment'
+	@header=$$($(GALITIME) --log stdout "true" | head -n 1); \
+	test "$$header" = "$(EXPECTED_HEADER)"
 
 clean:
 	rm -rf "$(VENV)"

--- a/tests/04_signal_exit_code/check_exit_code.py
+++ b/tests/04_signal_exit_code/check_exit_code.py
@@ -4,6 +4,7 @@ import csv
 import sys
 
 EXPECTED = '137'
+EXPECTED_STATUS = 'failed'
 PATH = sys.argv[1] if len(sys.argv) > 1 else 'out.tsv'
 
 with open(PATH, newline='') as f:
@@ -17,12 +18,21 @@ header = rows[0]
 data = rows[1]
 
 try:
-    idx = header.index('exit_code')
-except ValueError:
-    print('missing exit_code column', file=sys.stderr)
+    status_idx = header.index('status')
+    exit_code_idx = header.index('exit_code')
+except ValueError as err:
+    print(f'missing expected column: {err}', file=sys.stderr)
     sys.exit(2)
 
-actual = data[idx]
+status = data[status_idx]
+if status != EXPECTED_STATUS:
+    print(
+        f'       failed: expected status={EXPECTED_STATUS}, got {status}',
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+actual = data[exit_code_idx]
 if actual != EXPECTED:
     print(
         f'       failed: expected exit_code={EXPECTED} for SIGKILL (128+9), got {actual}',
@@ -31,5 +41,5 @@ if actual != EXPECTED:
     sys.exit(1)
 
 print(
-    f'       correct: exit_code={actual}; SIGKILL is reported as shell status 128+9, and galitime preserved that value.'
+    f'       correct: status={status} and exit_code={actual}; SIGKILL is reported as shell status 128+9, and galitime preserved that value.'
 )


### PR DESCRIPTION
closes #54

Updates the `galitime` TSV output schema and missing-value handling.

Changes:
- Removes `real_s_py` and `percent_cpu` from the default output.
- Adds `cpu_s`, computed as `user_s + sys_s`.
- Uses `NA` as the unified missing-value marker instead of Python `None`.
- Keeps `exit_code` based on the shell wait status, not GNU time's `%x`.
- Updates simple and installed-version tests to check the full expected header.

New output header:

```tsv
experiment	run	real_s	user_s	sys_s	cpu_s	max_ram_kb	fs_inputs	fs_outputs	exit_code	command